### PR TITLE
Add service interface for graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ Open Deep Research is compatible with many different LLMs:
 pip install open-deep-research
 ```
 
+### Run as a service
+
+Start a FastAPI server that exposes the graph workflow over HTTP:
+
+```bash
+uvicorn open_deep_research.service:app --host 0.0.0.0 --port 8000
+```
+
+You can then POST a topic to `/research` using Postman or `curl`:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"topic": "Your research topic"}' \
+     http://localhost:8000/research
+```
+
 See [src/open_deep_research/graph.ipynb](src/open_deep_research/graph.ipynb) and [src/open_deep_research/multi_agent.ipynb](src/open_deep_research/multi_agent.ipynb) for example usage in a Jupyter notebook:
 
 ## Open Deep Research Implementations

--- a/src/open_deep_research/service.py
+++ b/src/open_deep_research/service.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uuid
+from langgraph.types import Command
+from .graph import graph
+
+app = FastAPI()
+
+class TopicRequest(BaseModel):
+    topic: str
+
+class ResearchResponse(BaseModel):
+    report: str
+
+@app.post("/research", response_model=ResearchResponse)
+async def run_research(req: TopicRequest) -> ResearchResponse:
+    thread = {"configurable": {"thread_id": str(uuid.uuid4())}}
+
+    async for event in graph.astream({"topic": req.topic}, thread):
+        if "__interrupt__" in event:
+            break
+
+    async for _ in graph.astream(Command(resume=True), thread):
+        pass
+
+    state = graph.get_state(thread)
+    report = state.values.get("final_report", "")
+    return ResearchResponse(report=report)


### PR DESCRIPTION
## Summary
- create FastAPI service to run the research graph
- document how to launch the service and call it via POST

## Testing
- `pytest -q` *(fails: LangSmithAuthError due to missing API key)*

------
https://chatgpt.com/codex/tasks/task_e_684af81aa2448326b05825e9b2f06aa5